### PR TITLE
Configuration for phone.docs.ubuntu.com

### DIFF
--- a/deploy/site.yaml
+++ b/deploy/site.yaml
@@ -1,0 +1,20 @@
+domain: phone.docs.ubuntu.com
+
+image: prod-comms.docker-registry.canonical.com/phone.docs.ubuntu.com
+
+readinessPath: "/"
+
+# Overrides for production
+production:
+  replicas: 5
+
+  nginxConfigurationSnippet: |
+    more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect";
+
+# Overrides for staging
+staging:
+  replicas: 3
+
+  nginxConfigurationSnippet: |
+    more_set_headers "X-Robots-Tag: noindex";
+    more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect";

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 ubuntudesign.documentation-builder==1.5.0
+# Version pinned for compatibility:
+gitdb2==3.0.1


### PR DESCRIPTION
## Done

- K8s configuration for phone.docs.ubuntu.com. Fixes https://github.com/canonical-web-and-design/web-squad/issues/2964
- Pushed new docker image `prod-comms.docker-registry.canonical.com/phone.docs.ubuntu.com`

## QA
Edit your microk8s secret keys to include this new site:
`microk8s.kubectl edit secret secret-keys`
It should look like:
```yaml
data:
  phone-docs-ubuntu-com: cXMzbUJ5eFp3ZVBabkxUdFVadTJ1emFYb0NhdExkTW9nS0I0V1R6bg==
```
Then run:
`konf production deploy/site.yaml --local-qa | microk8s.kubectl apply -f -`
Check that everything is fine
`microk8s.kubectl get pods`
Edit your `/etc/hosts` file to point `phone.docs.ubuntu.com` to your local machine and check that site works
