### PR TITLE
Remove 'phone' from URL path

### DIFF
--- a/redirects.map
+++ b/redirects.map
@@ -1,2 +1,2 @@
-~^/(phone/?|en/?|phone/en)?$ /phone/en/;
+~^/(phone/?|phone/en)?$ /en/;
 


### PR DESCRIPTION
## Done

- Remove `/phone` from URL

## QA

1. `docker build --build-arg COMMIT_ID=test --tag phone-docs:test .`
2. `docker run -ti -p 80:80 phone-docs:test`
3. Go to http://localhost and check everything is fine and the final URL is `http://localhost/en/` instead of `http://localhost/phone/en/`